### PR TITLE
Modifying Regex for registration number

### DIFF
--- a/src/components/ClassroomComponent/BookingComponent/BookingComponent.js
+++ b/src/components/ClassroomComponent/BookingComponent/BookingComponent.js
@@ -220,7 +220,7 @@ class HorizontalLinearStepper extends React.Component {
       }
 
       if (fields['booker_reg_no'].length >= 1) {
-        if (!/^1[1-8][0-9]{7}$/.test(fields['booker_reg_no'])) {
+        if (!/^1[1-9][0-9]{7}$/.test(fields['booker_reg_no'])) {
           isFormValid = false
           errors['booker_reg_no'] = 'Registration number is not valid'
         }


### PR DESCRIPTION
Closes #107

### Description
Some registration numbers were not being accepted, for example, 190911112 is not getting accepted while creating an event.

Fixes #107 

### Type of Change:
- [ ] Bug fix (non-breaking change which fixes an issue)